### PR TITLE
🔧 Fix: Naprawa 3 krytycznych problemów interfejsu (Priority 1)

### DIFF
--- a/ui/commands.py
+++ b/ui/commands.py
@@ -814,6 +814,7 @@ class CommandParser:
             # Zapisz stan dialogu w grze
             self.game_state.current_dialogue = {
                 'npc_id': npc_found,
+                'npc_name': npc_obj.name if npc_obj else 'Nieznany',  # Dodane dla kontekstu dialogu
                 'node_id': 'greeting',
                 'options': options
             }

--- a/ui/contextual_menu.py
+++ b/ui/contextual_menu.py
@@ -30,6 +30,7 @@ class ContextualActionMenu:
         """
         self.game_state = game_state
         self.last_menu: List[ActionOption] = []
+        self.last_menu_location: Optional[str] = None  # Track location when menu was generated
 
         # Ikony dla kategorii
         self.category_icons = {
@@ -87,6 +88,7 @@ class ContextualActionMenu:
             counter += 1
 
         self.last_menu = actions
+        self.last_menu_location = self.game_state.current_location  # Zapisz lokację
         return actions
 
     def _get_people_actions(self) -> List[ActionOption]:
@@ -382,3 +384,24 @@ class ContextualActionMenu:
             True jeśli prawidłowy
         """
         return any(action.number == number for action in self.last_menu)
+
+    def is_menu_valid(self) -> bool:
+        """
+        Sprawdź czy ostatnie menu jest nadal aktualne.
+        Menu jest nieaktualne gdy lokacja się zmieniła.
+
+        Returns:
+            True jeśli menu jest aktualne
+        """
+        # Brak menu = nieaktualne
+        if not self.last_menu:
+            return False
+
+        # Sprawdź czy lokacja się zmieniła
+        current_location = self.game_state.current_location
+        return current_location == self.last_menu_location
+
+    def invalidate_menu(self):
+        """Unieważnij ostatnie menu (wymuś regenerację)."""
+        self.last_menu = []
+        self.last_menu_location = None


### PR DESCRIPTION
## NAPRAWIONE PROBLEMY:

### 1. 🔴 REDUNDANT DISPLAY (Problem #1)
**Poprzednio:**
- Każda iteracja: pełny ekran (STATUS + LOKACJA + QUICK KEYS) = 15-20 linii
- Po akcji: tylko rezultat
- Następna iteracja: znowu pełny ekran
- = OGROMNE SCROLLOWANIE

**Teraz:**
- Tracking stanu: `needs_full_refresh` + `last_location`
- Pełny ekran TYLKO gdy:
  - Pierwsza iteracja
  - Zmiana lokacji
  - Po dialogu
  - Po menu '?'
  - Komenda 'rozejrzyj'
- W innych przypadkach: KOMPAKTOWY (1 linia mini-status)

**Pliki zmienione:**
- ui/prologue_interface.py:
  - Dodano `needs_full_refresh`, `last_location` tracking
  - `display_game_screen(force_full)` - smart display
  - `_display_mini_status()` - kompaktowy status
  - `request_full_refresh()` - API dla wymuszania
- main.py:
  - Po dialogu: `request_full_refresh()`
  - Po 'rozejrzyj': `request_full_refresh()`
  - Tutorial progress: tylko gdy < 7 kroków

**Rezultat:** ~80% mniej scrollowania, lepszy UX

---

### 2. 🔴 NUMBERED ACTIONS STATE (Problem #2)
**Poprzednio:**
- `last_menu` persistent między lokacjami
- Gracz mógł wpisać "1" w nowej lokacji
- Wykonywała się STARA akcja z poprzedniej lokacji!
- = BŁĘDNE AKCJE

**Teraz:**
- Tracking lokacji: `last_menu_location`
- `is_menu_valid()` - sprawdza czy menu aktualne
- Przed użyciem numeru: walidacja
- Jeśli lokacja się zmieniła: error + hint "wciśnij ?"

**Pliki zmienione:**
- ui/contextual_menu.py:
  - Dodano `last_menu_location`
  - `is_menu_valid()` - walidacja
  - `invalidate_menu()` - czyszczenie
  - `generate_menu()` - zapisuje lokację
- ui/prologue_interface.py:
  - `get_input_with_quickkeys()` - sprawdza `is_menu_valid()`
  - Lepsze error messages

**Rezultat:** Numbered actions są bezpieczne, nie da się wykonać akcji z innej lokacji

---

### 3. 🔴 DIALOGUE CONTEXT (Problem #3)
**Poprzednio:**
- W dialogu: tylko tekst dialogu
- BRAK paneli STATUS/LOKACJA
- Gracz gubił kontekst (HP, gdzie jest, z kim rozmawia)

**Teraz:**
- Nowa metoda: `display_dialogue_context(npc_name)`
- Wyświetla: HP, Stamina, Lokacja, Rozmówca
- Kompaktowa linia (60 znaków)
- Wywoływana PRZED każdym promptem w dialogu

**Pliki zmienione:**
- ui/prologue_interface.py:
  - `display_dialogue_context(npc_name)` - kontekst dialogu
- ui/commands.py:
  - `current_dialogue` zawiera `npc_name`
- main.py:
  - W dialogu: `display_dialogue_context()` przed promptem

**Rezultat:** Gracz zawsze wie: HP, gdzie jest, z kim rozmawia

---

## TESTY:
✅ Wszystkie moduły importują się poprawnie
✅ ContextualActionMenu.is_menu_valid() działa
✅ PrologueInterface tracking działa
✅ Brak błędów składni

## PRZED/PO:

**PRZED (każda akcja):**
```
╔════ STATUS ════╗ (5 linii)
╔════ LOKACJA ═══╗ (7 linii)
╔═ QUICK KEYS ═══╗ (8 linii)
= 20 linii przed KAŻDĄ komendą
```

**TERAZ (typowa akcja):**
```
──────────────────────────────────
❤️100/100 ⚡80/100 📍Cela 1
──────────────────────────────────
= 3 linie przed większością komend
```

## IMPACT:
- 🟢 80% mniej scrollowania
- 🟢 Numbered actions bezpieczne
- 🟢 Kontekst w dialogach
- 🟢 Lepszy UX

NEXT: Priority 2 problems (quick key conflicts, post-action display)