### PR TITLE
fix: naprawy testów NPC AI i ekonomii (107/107 testów OK)

### DIFF
--- a/mechanics/economy.py
+++ b/mechanics/economy.py
@@ -899,8 +899,9 @@ class EnhancedEconomy(Economy):
                 'demand_factor': self._calculate_demand_factor(item_id),
                 'competition_factor': self._calculate_competition_factor(item_id)
             }
-            
-            ai_price = merchant_ai.calculate_selling_price(item_id, base_price, player_id, market_data)
+
+            # Użyj market_price (z event/seasonal modifiers) zamiast base_price
+            ai_price = merchant_ai.calculate_selling_price(item_id, market_price, player_id, market_data)
             return ai_price
         
         return market_price

--- a/mechanics/merchant_ai.py
+++ b/mechanics/merchant_ai.py
@@ -125,12 +125,13 @@ class MerchantMemory:
         """Zwraca całkowitą kwotę wydaną przez gracza"""
         if player_id not in self.player_transactions:
             return 0.0
-        
+
         total = 0.0
         for transaction in self.player_transactions[player_id]:
-            if transaction['type'] == 'purchase':
+            # 'sale' = handlarz sprzedał = gracz kupił = gracz wydał pieniądze
+            if transaction['type'] == 'sale':
                 total += transaction['amount']
-        
+
         return total
     
     def get_interaction_frequency(self, player_id: str, current_time: int) -> float:

--- a/npcs/npc_manager.py
+++ b/npcs/npc_manager.py
@@ -468,9 +468,9 @@ class NPC:
             g.completion
         ), reverse=True)
         
-        # Dezaktywuj ukończone cele
+        # Dezaktywuj ukończone cele (tolerancja dla błędów floating point)
         for goal in self.goals:
-            if goal.completion >= 1.0:
+            if goal.completion >= 0.9999:
                 goal.active = False
     
     def change_state(self, new_state: NPCState):

--- a/tests/test_enhanced_economy.py
+++ b/tests/test_enhanced_economy.py
@@ -69,13 +69,15 @@ class TestEconomicEvents(unittest.TestCase):
         """Test that events expire correctly"""
         current_time = 1000
         self.event_manager.force_event('niedobor_metalu', current_time)
-        
+
         # Event should be active
         self.assertEqual(len(self.event_manager.get_active_events()), 1)
-        
+
         # Fast forward past expiration
+        # Mock random to prevent new random events during update
         future_time = current_time + 800  # 800 minutes later (event lasts 720 minutes)
-        self.event_manager.update(future_time, {})
+        with patch('mechanics.economic_events.random.random', return_value=1.0):
+            self.event_manager.update(future_time, {})
         
         # Event should be expired
         self.assertEqual(len(self.event_manager.get_active_events()), 0)


### PR DESCRIPTION
Naprawiono błędy w testach i kodzie produkcyjnym:

NPC AI:
- Tolerancja float w _update_goals() (>= 0.9999 zamiast >= 1.0)
- Deterministyczna ucieczka gdy HP < 50% i pod atakiem
- Poprawione testy harmonogramu z mocking datetime
- Naprawione parametry constructor Injury w testach

Ekonomia:
- get_total_spent() liczy 'sale' zamiast 'purchase'
- get_enhanced_price() używa market_price z event modifiers
- Mock random w test_event_expiration

Wszystkie 107 testów przechodzą.